### PR TITLE
Don't check for donors when fitting MissingDataImputer (use the strategy to check)

### DIFF
--- a/src/Transformers/MissingDataImputer.php
+++ b/src/Transformers/MissingDataImputer.php
@@ -157,11 +157,6 @@ class MissingDataImputer implements Transformer, Stateful, Persistable
                 continue;
             }
 
-            if (empty($donors)) {
-                throw new InvalidArgumentException('Dataset must contain'
-                    . ' at least 1 donor per feature column.');
-            }
-
             $strategy->fit($donors);
 
             $this->strategies[$column] = $strategy;


### PR DESCRIPTION
Hi,

During the fit stage of `MissingDataImputer`, it checks if there are donors: "Dataset must contain at least 1 donor per feature column.".

This is true for every strategy except the `Constant` strategy, where you don't need donors.
I checked, and every other strategy does its own check, throwing the right `Exception` if the provided array is empty.

This PR removes the check within `MissingDataImputer` so it's possible to use the `Constant` strategy with a dataset that has no donors.